### PR TITLE
Anomoly Detection for Continous Readings of 0

### DIFF
--- a/src/EReg/Config.h
+++ b/src/EReg/Config.h
@@ -58,4 +58,7 @@ namespace Config {
     // Injector Feedforward Thresholds
     const float minInjectorFeedforwardAngle = 200;
     const float maxInjectorFeedforwardAngle = 900;
+
+    // Number of last readings that should be recorded
+    const int numReadingsStored = 3;
 }

--- a/src/EReg/States/FlowState.h
+++ b/src/EReg/States/FlowState.h
@@ -23,10 +23,14 @@ namespace StateMachine {
         float pressureSetpoint_;
         float angleSetpoint_;
 
+        float previousDownsteamPsiReadings[Config::numReadingsStored];
+        float previousUpsteamPsiReadings[Config::numReadingsStored];
+
         public:
         FlowState();
         void init();
         void update();
+        void updatePreviousReadingsArrays(float DownsteamPsi, float UpstreamPsi);
     };
 
     FlowState* getFlowState();


### PR DESCRIPTION
The added code stores a certain number of previous DownstreamPsi and UpstreamPsi readings and aborts if they are all 0.